### PR TITLE
samples/grpc/requirements: downgrade to 0.0.1

### DIFF
--- a/google-assistant-sdk/googlesamples/assistant/grpc/requirements.txt
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/requirements.txt
@@ -1,4 +1,4 @@
-google-assistant-grpc==0.0.2
+google-assistant-grpc==0.0.1
 google-auth-oauthlib==0.1.0
 urllib3[secure]==1.20
 sounddevice==0.3.7


### PR DESCRIPTION
Sample should always target the published version.