### PR TITLE
google-assistant-sdk/pushtotalk: fix conversation_stream handling

### DIFF
--- a/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
@@ -210,12 +210,12 @@ class SoundDeviceStream(object):
         return len(buf)
 
     def flush(self):
-        if self._flush_size > 0:
+        if self._audio_stream.active and self._flush_size > 0:
             self._audio_stream.write(b'\x00' * self._flush_size)
 
     def start(self):
         """Start the underlying stream."""
-        if self._audio_stream.active and not self._audio_stream.active:
+        if not self._audio_stream.active:
             self._audio_stream.start()
 
     def stop(self):

--- a/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
@@ -269,9 +269,12 @@ class ConversationStream(object):
         self._volume_percentage = 50
         self._stop_recording = threading.Event()
         self._source_lock = threading.RLock()
+        self._recording = False
+        self._playing = False
 
     def start_recording(self):
         """Start recording from the audio source."""
+        self._recording = True
         self._stop_recording.clear()
         self._source.start()
 
@@ -280,15 +283,26 @@ class ConversationStream(object):
         self._stop_recording.set()
         with self._source_lock:
             self._source.stop()
+        self._recording = False
 
     def start_playback(self):
         """Start playback to the audio sink."""
+        self._playing = True
         self._sink.start()
 
     def stop_playback(self):
         """Stop playback from the audio sink."""
         self._sink.flush()
         self._sink.stop()
+        self._playing = False
+
+    @property
+    def recording(self):
+        return self._recording
+
+    @property
+    def playing(self):
+        return self._playing
 
     @property
     def volume_percentage(self):

--- a/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
@@ -165,6 +165,9 @@ class WaveSink(object):
     def stop(self):
         pass
 
+    def flush(self):
+        pass
+
 
 class SoundDeviceStream(object):
     """Audio stream based on an underlying sound device.
@@ -212,13 +215,12 @@ class SoundDeviceStream(object):
 
     def start(self):
         """Start the underlying stream."""
-        if not self._audio_stream.active:
+        if self._audio_stream.active and not self._audio_stream.active:
             self._audio_stream.start()
 
     def stop(self):
         """Stop the underlying stream."""
         if self._audio_stream.active:
-            self.flush()
             self._audio_stream.stop()
 
     def close(self):
@@ -272,20 +274,21 @@ class ConversationStream(object):
         """Start recording from the audio source."""
         self._stop_recording.clear()
         self._source.start()
-        self._sink.start()
 
     def stop_recording(self):
         """Stop recording from the audio source."""
         self._stop_recording.set()
+        self._source.stop()
 
     def start_playback(self):
         """Start playback to the audio sink."""
         self._start_playback.set()
+        self._sink.start()
 
     def stop_playback(self):
         """Stop playback from the audio sink."""
         self._start_playback.clear()
-        self._source.stop()
+        self._sink.flush()
         self._sink.stop()
 
     @property

--- a/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
@@ -21,7 +21,6 @@ import os
 import os.path
 import pathlib2 as pathlib
 import sys
-import threading
 import uuid
 
 import click
@@ -121,20 +120,21 @@ class SampleAssistant(object):
         self.conversation_stream.start_recording()
         logging.info('Recording audio request.')
 
-        def iter_assist_requests():
+        def iter_log_assist_requests():
             for c in self.gen_assist_requests():
                 assistant_helpers.log_assist_request_without_audio(c)
                 yield c
-            self.conversation_stream.stop_recording()
+            logging.debug('Reached end of AssistRequest iteration.')
 
         # This generator yields AssistResponse proto messages
         # received from the gRPC Google Assistant API.
-        for resp in self.assistant.Assist(iter_assist_requests(),
+        for resp in self.assistant.Assist(iter_log_assist_requests(),
                                           self.deadline):
             assistant_helpers.log_assist_response_without_audio(resp)
             if resp.event_type == END_OF_UTTERANCE:
-                logging.info('End of audio request detected')
-                self.conversation_stream.end_of_utterance()
+                logging.info('End of audio request detected.')
+                logging.info('Stopping recording.')
+                self.conversation_stream.stop_recording()
             if resp.speech_results:
                 logging.info('Transcript of user request: "%s".',
                              ' '.join(r.transcript

--- a/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
@@ -123,7 +123,8 @@ class SampleAssistant(object):
         def iter_assist_requests():
             for c in self.gen_assist_requests():
                 assistant_helpers.log_assist_request_without_audio(c)
-                yield c                   
+                yield c
+            self.conversation_stream.stop_recording()
 
         # This generator yields AssistResponse proto messages
         # received from the gRPC Google Assistant API.
@@ -132,7 +133,6 @@ class SampleAssistant(object):
             assistant_helpers.log_assist_response_without_audio(resp)
             if resp.event_type == END_OF_UTTERANCE:
                 logging.info('End of audio request detected')
-                self.conversation_stream.stop_recording()
             if resp.speech_results:
                 logging.info('Transcript of user request: "%s".',
                              ' '.join(r.transcript

--- a/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
@@ -139,9 +139,10 @@ class SampleAssistant(object):
                 logging.info('Transcript of user request: "%s".',
                              ' '.join(r.transcript
                                       for r in resp.speech_results))
-                self.conversation_stream.start_playback()
-                logging.info('Playing assistant response.')
             if len(resp.audio_out.audio_data) > 0:
+                if not self.conversation_stream.playing:
+                    self.conversation_stream.start_playback()
+                    logging.info('Playing assistant response.')
                 self.conversation_stream.write(resp.audio_out.audio_data)
             if resp.dialog_state_out.conversation_state:
                 conversation_state = resp.dialog_state_out.conversation_state

--- a/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
@@ -123,8 +123,7 @@ class SampleAssistant(object):
         def iter_assist_requests():
             for c in self.gen_assist_requests():
                 assistant_helpers.log_assist_request_without_audio(c)
-                yield c
-            self.conversation_stream.start_playback()
+                yield c                   
 
         # This generator yields AssistResponse proto messages
         # received from the gRPC Google Assistant API.
@@ -138,6 +137,7 @@ class SampleAssistant(object):
                 logging.info('Transcript of user request: "%s".',
                              ' '.join(r.transcript
                                       for r in resp.speech_results))
+                self.conversation_stream.start_playback()
                 logging.info('Playing assistant response.')
             if len(resp.audio_out.audio_data) > 0:
                 self.conversation_stream.write(resp.audio_out.audio_data)
@@ -317,7 +317,6 @@ def main(api_endpoint, credentials, project_id,
     logging.info('Connecting to %s', api_endpoint)
 
     # Configure audio source and sink.
-    audio_device = None
     if input_audio_file:
         audio_source = audio_helpers.WaveSource(
             open(input_audio_file, 'rb'),
@@ -325,13 +324,11 @@ def main(api_endpoint, credentials, project_id,
             sample_width=audio_sample_width
         )
     else:
-        audio_source = audio_device = (
-            audio_device or audio_helpers.SoundDeviceStream(
+        audio_source = audio_helpers.SoundDeviceStream(
                 sample_rate=audio_sample_rate,
                 sample_width=audio_sample_width,
                 block_size=audio_block_size,
                 flush_size=audio_flush_size
-            )
         )
     if output_audio_file:
         audio_sink = audio_helpers.WaveSink(
@@ -340,13 +337,11 @@ def main(api_endpoint, credentials, project_id,
             sample_width=audio_sample_width
         )
     else:
-        audio_sink = audio_device = (
-            audio_device or audio_helpers.SoundDeviceStream(
+        audio_sink = audio_helpers.SoundDeviceStream(
                 sample_rate=audio_sample_rate,
                 sample_width=audio_sample_width,
                 block_size=audio_block_size,
                 flush_size=audio_flush_size
-            )
         )
     # Create conversation stream with the given audio source and sink.
     conversation_stream = audio_helpers.ConversationStream(

--- a/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/pushtotalk.py
@@ -21,6 +21,7 @@ import os
 import os.path
 import pathlib2 as pathlib
 import sys
+import threading
 import uuid
 
 import click
@@ -133,6 +134,7 @@ class SampleAssistant(object):
             assistant_helpers.log_assist_response_without_audio(resp)
             if resp.event_type == END_OF_UTTERANCE:
                 logging.info('End of audio request detected')
+                self.conversation_stream.end_of_utterance()
             if resp.speech_results:
                 logging.info('Transcript of user request: "%s".',
                              ' '.join(r.transcript

--- a/google-assistant-sdk/tests/test_audio_helpers.py
+++ b/google-assistant-sdk/tests/test_audio_helpers.py
@@ -133,6 +133,7 @@ class ConversationStreamTest(unittest.TestCase):
         self.assertEqual(b'foo\0', self.sink.getvalue())
 
     def test_sink_source_state(self):
+        self.assertEquals(False, self.source.started)
         self.stream.start_recording()
         self.assertEquals(True, self.source.started)
         self.stream.stop_recording()

--- a/google-assistant-sdk/tests/test_audio_helpers.py
+++ b/google-assistant-sdk/tests/test_audio_helpers.py
@@ -88,11 +88,18 @@ class WaveSinkTest(unittest.TestCase):
 
 
 class DummyStream(BytesIO):
+    started = False
+    stopped = False
+    flushed = False
+
     def start(self):
-        pass
+        self.started = True
 
     def stop(self):
-        pass
+        self.stopped = True
+
+    def flush(self):
+        self.flushed = True
 
 
 class ConversationStreamTest(unittest.TestCase):
@@ -125,6 +132,18 @@ class ConversationStreamTest(unittest.TestCase):
         self.assertEqual(True, self.playback_started)
         self.assertEqual(b'foo\0', self.sink.getvalue())
 
+    def test_sink_source_state(self):
+        self.stream.start_recording()
+        self.assertEquals(True, self.source.started)
+        self.stream.stop_recording()
+        self.assertEquals(True, self.source.stopped)
+        
+        self.assertEquals(False, self.sink.started)
+        self.stream.start_playback()
+        self.assertEquals(True, self.sink.started)
+        self.stream.stop_playback()
+        self.assertEquals(True, self.sink.stopped)
+        
     def test_oneshot_conversation(self):
         self.assertEqual(b'audio', self.stream.read(5))
         self.stream.stop_recording()


### PR DESCRIPTION
Fixes #186 #185 #155

- close stream on stop_recording
- restart stream on start_playback
- flush stream on stop_playback

The previous behaviour (keeping the stream open the whole time)
exposed a race condition where we tried to flush (write to) a stream
that was still recording (read-only mode).