### PR TITLE
Updated buf to use tobytes() as tostring() is deprecated

### DIFF
--- a/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
+++ b/google-assistant-sdk/googlesamples/assistant/grpc/audio_helpers.py
@@ -20,6 +20,7 @@ import math
 import time
 import threading
 import wave
+import sys
 
 import click
 import sounddevice as sd
@@ -54,7 +55,8 @@ def normalize_audio_buffer(buf, volume_percentage, sample_width=2):
     arr = array.array('h', buf)
     for idx in range(0, len(arr)):
         arr[idx] = int(arr[idx]*scale)
-    buf = arr.tostring()
+    # for python >= 3.2 use 'tobytes', otherwise 'tostring'
+    buf = arr.tobytes() if sys.version_info[0] >= 3 and sys.version_info[1] >= 2 else arr.tostring()
     return buf
 
 


### PR DESCRIPTION
Python v3.2 introduced `tobytes()` and kept the deprecated `tostring()` as an alias for `tobytes()`

This fix checks the current `sys.version_info` and chooses `arr.tobytes()` if the version is at least 3.2,\
otherwise it uses `arr.tostring()`